### PR TITLE
add __OpenBSD__ check to allow pathspec to work like linux

### DIFF
--- a/strife-ve-src/src/m_config.c
+++ b/strife-ve-src/src/m_config.c
@@ -2556,7 +2556,7 @@ static char *GetDefaultConfigDir(void)
         return M_Strdup(SVE_APPLE_PATH_S);
     }
     else
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__OpenBSD__)
     // Linux defaults
     // Configuration settings are stored in $XDG_DATA_HOME instead of $HOME on Linux.
 


### PR DESCRIPTION
Without this, builds on OpenBSD fall back to current directory behavior, so save games and config is saved in $PWD only.

As many other systems can be handled by the linux define here, I might suggest verifying the system type directly in the CMakeLists.txt file, then setting a flag such as -DXDG to allow this code to be followed on Linux, Open/Free/NetBSD, OpenIndiana, whatever else is out there that respects freedesktop standards.   At least rather than adding a big list directly to m_config.c :-)

If others are open to this idea, I'll figure out how to do this and submit a better patch