### PR TITLE
restore fallback darwin&linux config dir in the right place

### DIFF
--- a/strife-ve-src/src/m_config.c
+++ b/strife-ve-src/src/m_config.c
@@ -2618,6 +2618,9 @@ static char *GetDefaultConfigDir(void)
     }
     else
 #endif // #elif defined(__linux__)
+	{
+		return M_Strdup("");
+	}
 #else // #if !defined(_WIN32)
 #if defined(LUNA_RELEASE)
 	// Luna needs a standard savegame directory.


### PR DESCRIPTION
SVE does not build under linux systems because an `else` block was lost on [this line](https://github.com/svkaiser/strife-ve/commit/222623ccd864e45f576207ba7275068773c24854#diff-25bcf4ee25e0b5dfb9be349c97f4e5a5319f9b79b0b3e9501607df760685b995L2614) of 222623c; this PR fixes the issue by re-introducing it, moving it up an `ifdef` to take in account the changes from 222623c. Fixes #7.