### PR TITLE
add missing condition on darwin&linux steam service inclusion in cmakelists

### DIFF
--- a/strife-ve-src/CMakeLists.txt
+++ b/strife-ve-src/CMakeLists.txt
@@ -254,7 +254,7 @@ if(ENABLE_STEAM_SERVICE)
 	)
 
 	# Linux
-	if(NOT APPLE AND NOT WIN32)
+	if(NOT APPLE AND NOT WIN32 AND ENABLE_STEAM_SERVICE)
 		add_library(SteamService INTERFACE IMPORTED)
 		add_dependencies(SteamService steam-service-project)
 		target_compile_definitions(SteamService INTERFACE _USE_STEAM_)


### PR DESCRIPTION
It seems SteamService is always added on Darwin&Linux because a condition is missing in the CMakeLists.txt, so this PR adds it.