### PR TITLE
silence address to int conversion warning

### DIFF
--- a/strife-ve-src/src/strife/p_saveg.c
+++ b/strife-ve-src/src/strife/p_saveg.c
@@ -195,7 +195,7 @@ static void *saveg_readp(void)
 
 static void saveg_writep(const void *p)
 {
-    saveg_write32((int) p);
+    saveg_write32((intptr_t) p);
 }
 
 // Enum values are 32-bit integers.


### PR DESCRIPTION
Under Linux compiling `p_saveg.c` outputs a warning because of a pointer-to-int conversion. This PR casts it to `intptr_t` before to hide the warning, since it's done in other places in that file.